### PR TITLE
fix: enforcing UTC

### DIFF
--- a/src/adapters/filesystem/local-unit-of-work.ts
+++ b/src/adapters/filesystem/local-unit-of-work.ts
@@ -12,6 +12,7 @@ import type {
 } from "../../application/ports.js";
 import {
   SessionArchive,
+  UTC_TIMESTAMP_PATTERN,
   type SessionArchiveRecord,
   type SessionIdentity,
 } from "../../domain/model.js";
@@ -19,6 +20,7 @@ import { atomicWriteFile } from "./atomic-file.js";
 import { LocalFileObjectStore } from "./local-object-store.js";
 
 const Sha256Schema = Type.String({ pattern: "^[a-f0-9]{64}$" });
+const UtcTimestampSchema = Type.String({ pattern: UTC_TIMESTAMP_PATTERN });
 const ObjectReferenceSchema = Type.Object(
   {
     algorithm: Type.Literal("sha256"),
@@ -49,7 +51,7 @@ const CheckpointErrorSchema = Type.Object(
   {
     code: Type.String({ minLength: 1 }),
     message: Type.String({ minLength: 1 }),
-    occurredAt: Type.String({ minLength: 1 }),
+    occurredAt: UtcTimestampSchema,
     retryable: Type.Boolean(),
   },
   { additionalProperties: false },
@@ -70,8 +72,8 @@ const SessionArchiveRecordSchema = Type.Object(
     ),
     sessionObject: ObjectReferenceSchema,
     artifacts: Type.Array(ArtifactRelationSchema),
-    capturedAt: Type.String({ minLength: 1 }),
-    lastVerifiedAt: Type.String({ minLength: 1 }),
+    capturedAt: UtcTimestampSchema,
+    lastVerifiedAt: UtcTimestampSchema,
     lastError: Type.Optional(CheckpointErrorSchema),
   },
   { additionalProperties: false },

--- a/src/domain/model.ts
+++ b/src/domain/model.ts
@@ -1,5 +1,10 @@
 export type RepositoryIdentityKind = "git-remote" | "git-root" | "cwd";
 
+/** Canonical UTC format emitted by Date#toISOString(). */
+export const UTC_TIMESTAMP_PATTERN =
+  "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$";
+const UTC_TIMESTAMP_REGEX = new RegExp(UTC_TIMESTAMP_PATTERN);
+
 export interface RepositoryIdentity {
   kind: RepositoryIdentityKind;
   canonicalValue: string;
@@ -161,6 +166,7 @@ function assertRecordInvariants(record: SessionArchiveRecord): void {
   if (record.source.sha256 !== record.sessionObject.digest) {
     throw new Error("Session source SHA-256 must match the session object digest.");
   }
+  assertRecordTimestamps(record);
   for (const artifact of record.artifacts) {
     if (artifact.state === "captured" && !artifact.object) {
       throw new Error("A captured artifact relation must reference an object.");
@@ -168,5 +174,21 @@ function assertRecordInvariants(record: SessionArchiveRecord): void {
     if (artifact.state !== "captured" && artifact.object) {
       throw new Error("A missing or invalid artifact relation cannot reference an object.");
     }
+  }
+}
+
+function assertRecordTimestamps(record: SessionArchiveRecord): void {
+  assertUtcTimestamp(record.capturedAt, "capturedAt");
+  assertUtcTimestamp(record.lastVerifiedAt, "lastVerifiedAt");
+  if (record.lastError) assertUtcTimestamp(record.lastError.occurredAt, "lastError.occurredAt");
+}
+
+function assertUtcTimestamp(value: string, field: string): void {
+  if (!UTC_TIMESTAMP_REGEX.test(value)) {
+    throw new Error(`${field} must be a canonical UTC ISO 8601 timestamp.`);
+  }
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds) || new Date(milliseconds).toISOString() !== value) {
+    throw new Error(`${field} must be a valid canonical UTC ISO 8601 timestamp.`);
   }
 }

--- a/test/integration/adapters/local-unit-of-work.test.ts
+++ b/test/integration/adapters/local-unit-of-work.test.ts
@@ -107,8 +107,8 @@ describe("LocalCheckpointUnitOfWork", () => {
       source: { size: 20, mtimeMs: 2, sha256: stored.object.digest },
       sessionObject: stored.object,
       artifacts: [],
-      capturedAt: "later",
-      lastVerifiedAt: "later",
+      capturedAt: "2026-08-03T00:00:01.000Z",
+      lastVerifiedAt: "2026-08-03T00:00:01.000Z",
     });
     const failingRepository = new LocalSessionArchiveRepository(root, {
       atomicWrite: async () => {
@@ -140,6 +140,21 @@ describe("LocalCheckpointUnitOfWork", () => {
     await expect(repository.get({ repositoryId: "repo-id", sessionId: "session-id" })).rejects.toThrow(
       "contains invalid JSON",
     );
+  });
+
+  it.each([
+    ["2026-08-03T00:00:00.000+00:00", "Invalid session archive record"],
+    ["2026-02-30T00:00:00.000Z", "capturedAt must be a valid"],
+  ])("rejects persisted non-UTC or invalid timestamp %s", async (capturedAt, error) => {
+    const { root, stored } = await fixture();
+    const repository = new LocalSessionArchiveRepository(root);
+    const identity = { repositoryId: "repo-id", sessionId: "session-id" };
+    const path = repository.recordPath(identity);
+    const record = archiveFor(stored.object).record!;
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify({ ...record, capturedAt }));
+
+    await expect(repository.get(identity)).rejects.toThrow(error);
   });
 
   it("validates persisted aggregate records before rehydrating the domain", async () => {

--- a/test/unit/domain/session-archive.test.ts
+++ b/test/unit/domain/session-archive.test.ts
@@ -41,15 +41,15 @@ describe("SessionArchive aggregate", () => {
       source: { size: 10, mtimeMs: 1, sha256: digest },
       sessionObject: object(),
       artifacts: [],
-      capturedAt: "first",
-      lastVerifiedAt: "first",
+      capturedAt: "2026-08-03T00:00:01.000Z",
+      lastVerifiedAt: "2026-08-03T00:00:01.000Z",
     });
     const second = archive.recordCheckpoint({
       source: { size: 11, mtimeMs: 2, sha256: digest },
       sessionObject: object(),
       artifacts: [],
-      capturedAt: "second",
-      lastVerifiedAt: "second",
+      capturedAt: "2026-08-03T00:00:02.000Z",
+      lastVerifiedAt: "2026-08-03T00:00:02.000Z",
     });
 
     expect(first.revision).toBe(1);
@@ -71,8 +71,8 @@ describe("SessionArchive aggregate", () => {
         source: { size: 10, mtimeMs: 1, sha256: "b".repeat(64) },
         sessionObject: object(),
         artifacts: [],
-        capturedAt: "now",
-        lastVerifiedAt: "now",
+        capturedAt: "2026-08-03T00:00:00.000Z",
+        lastVerifiedAt: "2026-08-03T00:00:00.000Z",
       }),
     ).toThrow("must match");
   });
@@ -92,10 +92,41 @@ describe("SessionArchive aggregate", () => {
             state: "captured",
           },
         ],
-        capturedAt: "now",
-        lastVerifiedAt: "now",
+        capturedAt: "2026-08-03T00:00:00.000Z",
+        lastVerifiedAt: "2026-08-03T00:00:00.000Z",
       }),
     ).toThrow("must reference an object");
+  });
+
+  it.each([
+    ["offset timestamps", "2026-08-03T00:00:00.000+00:00"],
+    ["timestamps without milliseconds", "2026-08-03T00:00:00Z"],
+    ["impossible calendar dates", "2026-02-30T00:00:00.000Z"],
+  ])("rejects %s", (_description, capturedAt) => {
+    expect(() => SessionArchive.rehydrate({ ...record(), capturedAt })).toThrow(
+      "capturedAt must be",
+    );
+  });
+
+  it("requires UTC timestamps for verification and persisted errors", () => {
+    expect(() =>
+      SessionArchive.rehydrate({
+        ...record(),
+        lastVerifiedAt: "2026-08-03T00:00:00.000-04:00",
+      }),
+    ).toThrow("lastVerifiedAt must be");
+
+    expect(() =>
+      SessionArchive.rehydrate({
+        ...record(),
+        lastError: {
+          code: "CHECKPOINT_FAILED",
+          message: "failed",
+          occurredAt: "not-a-timestamp",
+          retryable: true,
+        },
+      }),
+    ).toThrow("lastError.occurredAt must be");
   });
 
   it("returns defensive copies instead of exposing aggregate state", () => {


### PR DESCRIPTION
## Summary
- enforce canonical UTC ISO 8601 timestamps in session archive domain invariants
- validate persisted catalog timestamps with the shared UTC pattern
- cover invalid dates, offsets, missing milliseconds, verification timestamps, and error timestamps

## Validation
- `TZ=UTC npx vitest run test/unit/domain/session-archive.test.ts test/integration/adapters/local-unit-of-work.test.ts`
- `TZ=America/New_York npx vitest run test/unit/domain/session-archive.test.ts test/integration/adapters/local-unit-of-work.test.ts`
- `npm run check`
- `npm run analyze:audit -- --base HEAD`